### PR TITLE
fix: update API endpoints to use relative paths

### DIFF
--- a/frontend/src/components/authen-form/LoginPage.jsx
+++ b/frontend/src/components/authen-form/LoginPage.jsx
@@ -28,7 +28,7 @@ const Login = () => {
   const handleSubmit = async (e) => {
     e.preventDefault()
     try {
-      const response = await api.post('https://localhost:7195/Account/login', {
+      const response = await api.post('/Account/login', {
         email,
         password
       })

--- a/frontend/src/configs/axios.js
+++ b/frontend/src/configs/axios.js
@@ -56,7 +56,7 @@ api.interceptors.response.use(
       isRefreshing = true
 
       try {
-        const res = await axios.post('https://localhost:7195/Account/refresh-token', {}, { withCredentials: true })
+        const res = await api.post('/Account/refresh-token', {}, { withCredentials: true })
         const newAccessToken = res.data.accessToken
         localStorage.setItem('token', newAccessToken)
         api.defaults.headers.common['Authorization'] = 'Bearer ' + newAccessToken

--- a/frontend/src/pages/test-service/index.jsx
+++ b/frontend/src/pages/test-service/index.jsx
@@ -20,7 +20,7 @@ const Services = () => {
   const fetchServices = async () => {
     setLoading(true);
     try {
-      const response = await axios.get("https://localhost:7195/api/services");
+      const response = await axios.get("/api/services");
       console.log(response);
       
       setServices(response.data);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated API requests to use relative URLs with the configured API instance instead of hardcoded absolute URLs. This change applies to login, token refresh, and service data fetching actions. End-users should experience consistent connectivity without visible changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->